### PR TITLE
Private stats mode write data inside a file

### DIFF
--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -19,10 +19,17 @@ type TwitchCreds struct {
 	Username string
 }
 
+// Stats is a structure containing config related to stats generation
+type Stats struct {
+	// Base dir path used to store generated files
+	Dir string
+}
+
 // Conf is a meta structure containing all nedded configuration for a gambling instance
 type Conf struct {
 	Pastebin PastebinCreds
 	Twitch   TwitchCreds
+	Stats    Stats
 	Admins   []string
 	Hello    string
 	Prefix   string

--- a/internal/app/gambling.go
+++ b/internal/app/gambling.go
@@ -250,7 +250,7 @@ func (g *Gambling) handleStat(user twitch.User, args []string) {
 		return
 	}
 
-	// create stats and sotre it into a string
+	// create stats and store it into a string
 	stats := createStat(g.CurrentVote)
 	// Check args, if private mode is requested
 	if len(args) >= 1 {

--- a/internal/app/gambling.go
+++ b/internal/app/gambling.go
@@ -256,8 +256,11 @@ func (g *Gambling) handleStat(user twitch.User, args []string) {
 	if len(args) >= 1 {
 		if strings.ToLower(args[0]) == "private" {
 			// Do it in private
-			// TODO: write into a file
-			fmt.Println(stats)
+			err := statsToFile(stats, g.Config.Stats.Dir)
+			if err != nil {
+				fmt.Println(err)
+				g.say("Error generating stats in private mode")
+			}
 			g.say("Stats generated in private mode")
 			return
 		}

--- a/internal/app/gambling.go
+++ b/internal/app/gambling.go
@@ -243,28 +243,34 @@ func (g *Gambling) handleReset(user twitch.User) {
 	g.CurrentVote.Votes = make(map[string]string)
 }
 
-// handle a call to stats generation (public)
+// handle a call to stats generation (public or private)
 func (g *Gambling) handleStat(user twitch.User, args []string) {
 
 	if !checkPermission(user.Name, g.Config.Admins) {
 		return
 	}
 
-	if link, err := createStat(g.Config.Pastebin.Key, g.CurrentVote); err == nil {
-		message := fmt.Sprintf("Stats generated, see %s", link)
-		if len(args) >= 1 {
-			if strings.ToLower(args[0]) == "private" {
-				fmt.Println(message)
-				return
-			}
+	// create stats and sotre it into a string
+	stats := createStat(g.CurrentVote)
+	// Check args, if private mode is requested
+	if len(args) >= 1 {
+		if strings.ToLower(args[0]) == "private" {
+			// Do it in private
+			// TODO: write into a file
+			fmt.Println(stats)
+			g.say("Stats generated in private mode")
+			return
 		}
-
-		g.say(message)
-
 	} else {
-		fmt.Println("Error while generating pastebin")
-		fmt.Println(err)
+		// If not in private mode, go public, and paste to pastebin
+		link, err := statsToPastebin(g.Config.Pastebin.Key, stats)
+		if err != nil {
+			g.say("Error generating stats in public mode")
+			fmt.Println(err)
+		}
+		g.say(fmt.Sprintf("Stats generated in public mode, check it at : %s", link))
 	}
+
 }
 
 // handle roll and select winner

--- a/internal/app/stats.go
+++ b/internal/app/stats.go
@@ -7,9 +7,8 @@ import (
 	"github.com/Ronmi/pastebin"
 )
 
-// Create stats from vote and paste it to pastebin
-func createStat(key string, votes *Vote) (string, error) {
-	api := pastebin.API{Key: key}
+// Create stats from vote
+func createStat(votes *Vote) string {
 
 	transformed := make(map[string][]string)
 	for user, value := range votes.Votes {
@@ -26,11 +25,8 @@ func createStat(key string, votes *Vote) (string, error) {
 		str += value + " (" + strconv.Itoa(len(users)) + "): " + strings.Join(users, ", ") + "\n"
 	}
 
-	return api.Post(&pastebin.Paste{
-		Title:    "Stat Vote",
-		Content:  str,
-		ExpireAt: pastebin.In1D,
-	})
+	return str
+
 }
 
 // Push stats to pastebin as string

--- a/internal/app/stats.go
+++ b/internal/app/stats.go
@@ -52,7 +52,7 @@ func statsToFile(stats string, dir string) error {
 	dt := time.Now()
 
 	// forge base dir
-	basedir := fmt.Sprintf("%s/%s", dir, dt.Format("01-02-2000"))
+	basedir := fmt.Sprintf("%s/%s", dir, dt.Format("2006-01-02"))
 	// create base dir if not exists
 	if _, err := os.Stat(basedir); os.IsNotExist(err) {
 		os.Mkdir(basedir, 0766)

--- a/internal/app/stats.go
+++ b/internal/app/stats.go
@@ -32,3 +32,15 @@ func createStat(key string, votes *Vote) (string, error) {
 		ExpireAt: pastebin.In1D,
 	})
 }
+
+// Push stats to pastebin as string
+func statsToPastebin(key string, stats string) (string, error) {
+	api := pastebin.API{Key: key}
+
+	return api.Post(&pastebin.Paste{
+		Title:    "Stat Vote",
+		Content:  stats,
+		ExpireAt: pastebin.In1D,
+	})
+
+}

--- a/internal/app/stats.go
+++ b/internal/app/stats.go
@@ -1,8 +1,11 @@
 package app
 
 import (
+	"fmt"
+	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Ronmi/pastebin"
 )
@@ -38,5 +41,34 @@ func statsToPastebin(key string, stats string) (string, error) {
 		Content:  stats,
 		ExpireAt: pastebin.In1D,
 	})
+
+}
+
+// Write stats into a file inside a base directory
+func statsToFile(stats string, dir string) error {
+
+	// Create a directory using current date
+	// get current date
+	dt := time.Now()
+
+	// forge base dir
+	basedir := fmt.Sprintf("%s/%s", dir, dt.Format("01-02-2000"))
+	// create base dir if not exists
+	if _, err := os.Stat(basedir); os.IsNotExist(err) {
+		os.Mkdir(basedir, 0766)
+	}
+
+	// Create file
+	f, err := os.Create(fmt.Sprintf("%s/stats", basedir))
+	if err != nil {
+		return err
+	}
+	// Ensure file is closed at the end of the func
+	defer f.Close()
+
+	// Write stuff and return err
+	_, err = f.WriteString(stats)
+
+	return err
 
 }


### PR DESCRIPTION
In order to allow remote hosting of the bot, here is a solution for private stats access :

- Ask for private stats generation
- Write stats into file, put it inside directories named using date
- Make file available on a public web server with a basic auth (user/password)

Final url will be something like : https://gamble.mafr.example.com/2019-10-30/stats

For public stats, we should keep pastebin for now.
